### PR TITLE
[fix] Added some delay for UX actions

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -301,7 +301,8 @@ gulp.task("server-watch", ["html-inject-watch", "html2js-watch", "config", "font
 gulp.task("server-close", factory.testServerClose());
 gulp.task("test:webdrive_update", factory.webdriveUpdate());
 gulp.task("test:e2e:core", ["test:webdrive_update"], factory.testE2EAngular({
-  browser: "chrome"
+  browser: "chrome",
+  testFiles: ["./test/e2e/**/*-scenarios.js"]
 }));
 gulp.task("test:e2e", function (cb) {
   runSequence("server", "test:e2e:core", "server-close", cb);

--- a/test/e2e/authentication-scenarios.js
+++ b/test/e2e/authentication-scenarios.js
@@ -39,9 +39,12 @@
 
     it("should retain auth status upon refresh", function () {
       browser.refresh();
+      
+      browser.sleep(500);
+
       assert.eventually.isFalse(element(by.css("button.sign-in")).isDisplayed(), "sign in button should not show");
       assert.eventually.isTrue(element(by.css(".user-profile-dropdown img.profile-pic")).isDisplayed(), "profile pic should show");
-      assert.eventually.isFalse((element(by.css(".sign-out-button")).isDisplayed()), "sign out button should not show");
+      assert.eventually.isFalse((element(by.css(".dropdown-menu .sign-out-button")).isDisplayed()), "sign out button should not show");
     });
 
     it("should log out", function() {
@@ -55,10 +58,13 @@
       element(by.css(".user-profile-dropdown img.profile-pic")).click();
 
       //shows sign-out menu item
-      expect(element(by.css(".sign-out-button")).isDisplayed()).to.eventually.equal(true);
+      expect(element(by.css(".dropdown-menu .sign-out-button")).isDisplayed()).to.eventually.equal(true);
 
       //click sign out
-      element(by.css(".sign-out-button")).click();
+      element(by.css(".dropdown-menu .sign-out-button")).click();
+      
+      browser.sleep(500);
+      
       assert.eventually.isTrue(element(by.css(".sign-out-modal")).isDisplayed(), "sign-out dialog should show");
       element(by.css(".sign-out-modal .sign-out-rv-only-button")).click();
 

--- a/test/e2e/company-settings-scenarios.js
+++ b/test/e2e/company-settings-scenarios.js
@@ -32,14 +32,16 @@
         it("logs in", function () {
           browser.executeScript("gapi.setPendingSignInUser('michael.sanchez@awesome.io')");
           element(by.css("button.sign-in")).click();
+          browser.sleep(500);
           assert.eventually.isFalse(element(by.css("button.sign-in")).isDisplayed(), "sign in button should not show");
         });
 
         it("Opens Company Settings Dialog", function() {
           element(by.css(".user-profile-dropdown img.profile-pic")).click();
-          assert.eventually.isTrue(element(by.css(".company-settings-menu-button")).isDisplayed(),
+          assert.eventually.isTrue(element(by.css(".dropdown-menu .company-settings-menu-button")).isDisplayed(),
             "Company settings menu item should present");
-          element(by.css(".company-settings-menu-button")).click();
+          element(by.css(".dropdown-menu .company-settings-menu-button")).click();
+          browser.sleep(500);
           assert.eventually.isTrue(element(by.css(".company-settings-modal")).isDisplayed(),
             "Company settings dialog should show");
         });
@@ -66,9 +68,10 @@
       describe("Delete Company", function () {
         it("Opens Company Settings Dialog", function() {
           element(by.css(".user-profile-dropdown img.profile-pic")).click();
-          assert.eventually.isTrue(element(by.css(".company-settings-menu-button")).isDisplayed(),
+          assert.eventually.isTrue(element(by.css(".dropdown-menu .company-settings-menu-button")).isDisplayed(),
             "Company settings menu item should present");
-          element(by.css(".company-settings-menu-button")).click();
+          element(by.css(".dropdown-menu .company-settings-menu-button")).click();
+          browser.sleep(500);
           assert.eventually.isTrue(element(by.css(".company-settings-modal")).isDisplayed(),
             "Company settings dialog should show");
         });

--- a/test/e2e/company-subcompanies-scenarios.js
+++ b/test/e2e/company-subcompanies-scenarios.js
@@ -52,6 +52,7 @@
 
           browser.executeScript("gapi.setPendingSignInUser('michael.sanchez@awesome.io')");
           element(by.css("button.sign-in")).click();
+          browser.sleep(500);
           assert.eventually.isFalse(element(by.css("button.sign-in")).isDisplayed(), "sign in button should not show");
 
           browser.get("/test/e2e/index.html#/shopping-cart?cid=" +
@@ -63,8 +64,9 @@
             
           browser.get("/test/e2e/index.html#/shopping-cart");
           browser.refresh();
-          assert.eventually.isFalse(element(by.css(".sub-company-alert")).isPresent() &&
-            element(by.css(".sub-company-alert")).isDisplayed(),
+          browser.sleep(500);
+          assert.eventually.isFalse(element(by.css(".common-header-alert.sub-company-alert")).isPresent() &&
+            element(by.css(".common-header-alert.sub-company-alert")).isDisplayed(),
             "subcompany alert should hide");
         });
       });
@@ -72,17 +74,17 @@
       describe("Add subcompany & move company", function () {
         it("Opens Add Subcompany dialog", function () {
           element(by.css(".user-profile-dropdown img.profile-pic")).click();
-          assert.eventually.isTrue(element(by.css(".add-subcompany-menu-button")).isDisplayed(),
+          assert.eventually.isTrue(element(by.css(".dropdown-menu .add-subcompany-menu-button")).isDisplayed(),
             "Add subcompany menu item should show");
-          element(by.css(".add-subcompany-menu-button")).click();
+          element(by.css(".dropdown-menu .add-subcompany-menu-button")).click();
+          browser.sleep(500);
           assert.eventually.isTrue(element(by.css(".pt-add-subcompany-modal")).isDisplayed(),
             "Add subcompany dialog should show");
-            browser.sleep(500);
         });
 
         it("Opens Move Company Dialog", function() {
           element(by.css(".move-subcompany-button")).click();
-
+          browser.sleep(500);
           assert.eventually.isTrue(element(by.css(".move-company-modal")).isDisplayed(),
             "Move company dialog should show");
         });
@@ -106,6 +108,7 @@
 
         it("Should Move Company", function () {
           element(by.css(".move-company-button")).click();
+          browser.sleep(500);
           assert.eventually.isTrue(element(by.css(".alert.alert-success")).isDisplayed(),
             "Success message should show");
           assert.eventually.isFalse(element(by.css(".move-company-button")).isDisplayed(),
@@ -125,6 +128,5 @@
             "Add subcompany dialog should hide");
         });
       });
-
   });
 })();

--- a/test/e2e/company-users-scenarios.js
+++ b/test/e2e/company-users-scenarios.js
@@ -36,9 +36,12 @@
 
         it("Opens Company Users Dialog and load company users", function() {
           element(by.css(".user-profile-dropdown img.profile-pic")).click();
-          assert.eventually.isTrue(element(by.css(".company-users-menu-button")).isDisplayed(),
+          assert.eventually.isTrue(element(by.css(".dropdown-menu .company-users-menu-button")).isDisplayed(),
             "Company users menu item should present");
-          element(by.css(".company-users-menu-button")).click();
+          element(by.css(".dropdown-menu .company-users-menu-button")).click();
+
+          browser.sleep(500);
+
           assert.eventually.isTrue(element(by.css(".company-users-modal")).isDisplayed(),
             "Company users dialog should show");
         });
@@ -50,6 +53,9 @@
 
         it("opens up Add User dialog", function () {
           element(by.css("button.add-company-user-button")).click();
+          
+          browser.sleep(500);
+
           assert.eventually.isTrue(element(by.css(".user-settings-modal")).isPresent(), "Add user dialog should show");
         });
 

--- a/test/e2e/registration-scenarios.js
+++ b/test/e2e/registration-scenarios.js
@@ -33,7 +33,9 @@
         //click on sign in button
         browser.executeScript("gapi.setPendingSignInUser('john.doe@awesome.io')");
         element(by.css("button.sign-in")).click();
-
+        
+        browser.sleep(500);
+        
         //dialog shows
         assert.eventually.isTrue(element(by.css(".registration-modal")).isPresent(), "registration dialog should show");
 
@@ -50,11 +52,11 @@
       it("allow me to register when I've changed my mind", function() {
         assert.eventually.isTrue(element(by.css(".register-user-menu-button")).isDisplayed(), "Create Account button should show");
         element(by.css(".register-user-menu-button")).click();
+        browser.sleep(500);
         assert.eventually.isTrue(element(by.css(".registration-modal")).isPresent(), "registration dialog should show");
       });
 
       it("should show validation errors if i have not agreed to terms and entered an email", function () {
-        browser.sleep(500);
         element(by.css(".registration-save-button")).click();
         assert.eventually.isTrue(element(by.css(".validation-error-message-accepted")).isPresent(), "t&c validation error should show");
         assert.eventually.isTrue(element(by.css(".validation-error-message-first-name")).isPresent(), "first name validation error should show");

--- a/test/e2e/shoppingcart-scenarios.js
+++ b/test/e2e/shoppingcart-scenarios.js
@@ -86,9 +86,9 @@
 
         element(by.css(".desktop-menu-item img.profile-pic")).click();
         //shows sign-out menu item
-        expect(element(by.css(".sign-out-button")).isDisplayed()).to.eventually.equal(true);
+        expect(element(by.css(".dropdown-menu .sign-out-button")).isDisplayed()).to.eventually.equal(true);
         //click sign out
-        element(by.css(".sign-out-button")).click();
+        element(by.css(".dropdown-menu .sign-out-button")).click();
         assert.eventually.isTrue(element(by.css(".sign-out-modal")).isDisplayed(), "sign-out dialog should show");
         element(by.css(".sign-out-modal .sign-out-rv-only-button")).click();
 
@@ -97,7 +97,9 @@
         //log in
         browser.executeScript("gapi.setPendingSignInUser('michael.sanchez@awesome.io')");
         element(by.css("button.sign-in")).click();
-
+        
+        browser.sleep(500);
+        
         assert.eventually.strictEqual(element(by.id("cartBadge")).getText(), "2", "Cart badge should display 2");
       });
 

--- a/test/e2e/superman-scenarios.js
+++ b/test/e2e/superman-scenarios.js
@@ -34,6 +34,7 @@
         //log in
         browser.executeScript("gapi.setPendingSignInUser('michael.sanchez@awesome.io')");
         element(by.id("ps-become-superman")).click();
+        browser.sleep(500);
         assert.eventually.isFalse(element(by.id("ps-become-superman")).isDisplayed(), "Should show Become Superman button");
         //superman!
         assert.eventually.isTrue(element(by.id("ps-superman-badge")).isDisplayed(), "Should show Become Superman button");
@@ -42,9 +43,12 @@
       it("should hide superman identity when user is logged out", function() {
         element(by.css(".desktop-menu-item img.profile-pic")).click();
         //shows sign-out menu item
-        expect(element(by.css(".sign-out-button")).isDisplayed()).to.eventually.equal(true);
+        expect(element(by.css(".dropdown-menu .sign-out-button")).isDisplayed()).to.eventually.equal(true);
         //click sign out
-        element(by.css(".sign-out-button")).click();
+        element(by.css(".dropdown-menu .sign-out-button")).click();
+        
+        browser.sleep(500);
+        
         assert.eventually.isTrue(element(by.css(".sign-out-modal")).isDisplayed(), "sign-out dialog should show");
         element(by.css(".sign-out-modal .sign-out-rv-only-button")).click();
 

--- a/test/e2e/system-messages-scenarios.js
+++ b/test/e2e/system-messages-scenarios.js
@@ -27,24 +27,28 @@
 
       it("should not show system message icon when not logged in", function() {
         assert.eventually.isTrue(element(by.css("button.sign-in")).isDisplayed(), "Sign in button should show");
-        assert.eventually.isFalse(element(by.css(".system-messages-button")).isDisplayed(), "Should not show system messages icon");
-        assert.eventually.strictEqual(element(by.css(".system-messages-badge")).getText(), "", "Should not show system message badge");
+        assert.eventually.isFalse(element(by.css(".dropdown .system-messages-button")).isDisplayed(), "Should not show system messages icon");
+        assert.eventually.strictEqual(element(by.css(".dropdown .system-messages-badge")).getText(), "", "Should not show system message badge");
       });
 
       it("should show system messages when logged in", function() {
         //log in
         browser.executeScript("gapi.setPendingSignInUser('michael.sanchez@awesome.io')");
         element(by.css("button.sign-in")).click();
+        
+        browser.sleep(500);
 
-        assert.eventually.isTrue(element(by.css(".system-messages-button")).isDisplayed(), "Should show system messages icon");
-        assert.eventually.strictEqual(element(by.css(".system-messages-badge")).getText(), "14", "Badge should show correct number of system messages");
+        assert.eventually.isTrue(element(by.css(".dropdown .system-messages-button")).isDisplayed(), "Should show system messages icon");
+        assert.eventually.strictEqual(element(by.css(".dropdown .system-messages-badge")).getText(), "14", "Badge should show correct number of system messages");
       });
 
       it("should hide system messages icon when there are no messages", function() {
         element(by.id("clear-system-messages-button")).click();
         browser.refresh();
+        
+        browser.sleep(500);
 
-        assert.eventually.isFalse(element(by.css(".system-messages-button")).isDisplayed(), "Should hide system messages icon");
+        assert.eventually.isFalse(element(by.css(".dropdown .system-messages-button")).isDisplayed(), "Should hide system messages icon");
       });
   });
 })();

--- a/test/e2e/user-settings-scenarios.js
+++ b/test/e2e/user-settings-scenarios.js
@@ -34,10 +34,12 @@
         assert.eventually.isFalse(element(by.css("button.sign-in")).isDisplayed(), "sign in button should not show");
 
         element(by.css(".user-profile-dropdown img.profile-pic")).click();
-        assert.eventually.isTrue(element(by.css(".user-settings-button")).isDisplayed(), "User settings menu item should show");
+        assert.eventually.isTrue(element(by.css(".dropdown-menu .user-settings-button")).isDisplayed(), "User settings menu item should show");
 
         //click on user settings button
-        element(by.css(".user-settings-button")).click();
+        element(by.css(".dropdown-menu .user-settings-button")).click();
+        
+        browser.sleep(500);
 
         assert.eventually.isTrue(element(by.css(".user-settings-modal"))
           .isDisplayed(), "User settings modal should show after clicking on menu item");


### PR DESCRIPTION
Fixed css selector warnings

Logging out and back in from `shopping-cart-scenarios.js` was failing because of gapi-mock issue. 

However, tests were also randomly failing at different points. I believe it was the action of opening dialogs that was causing this failure. Namely, the transition delay shown when opening the dialog may have caused selectors to come up empty. Added `sleep()` timeouts to alleviate this, so far so good (3 builds in a row, will keep trying). 

@olegrise please review. Thanks!