### PR TITLE
Allow application to overwrite closeIFrame() function.

### DIFF
--- a/src/js/controllers/ctr-close-frame.js
+++ b/src/js/controllers/ctr-close-frame.js
@@ -1,11 +1,15 @@
 angular.module("risevision.common.header")
 
 .controller("CloseFrameButtonCtrl", [
-  "$scope", "$log", "gadgetsService",
-  function ($scope, $log, gadgetsService) {
+  "$scope", "$log", "gadgetsService", "$rootScope",
+  function ($scope, $log, gadgetsService, $rootScope) {
     $scope.closeIFrame = function () {
-      $log.debug("gadgetsService.closeIFrame");
-      gadgetsService.closeIFrame();
+      if (typeof $rootScope.closeIFrame === "function") {
+        $rootScope.closeIFrame();
+      } else {
+        $log.debug("gadgetsService.closeIFrame");
+        gadgetsService.closeIFrame();
+      }
     };
 
   }


### PR DESCRIPTION
@alex-deaconu what do you think of this change? 

The use case is following:
- User goes to the Store from RVA by pressing "Add from Template" button
- User buys a template
- User close Store by pressing [X] button
- Store return Template ID to the RVA and then RVA creates a presentation

I was thinking of defining a variable which would define action type for the [X] button and then product code that has to be returned, but then realized that probably the cleanest way is to simply let the Store to overwrite the closeIFrame() function.